### PR TITLE
Enhancement- Include segment patches

### DIFF
--- a/mpldts/geometry/__init__.py
+++ b/mpldts/geometry/__init__.py
@@ -4,3 +4,5 @@ from mpldts.geometry.station import Station
 from mpldts.geometry.super_layer import SuperLayer
 from mpldts.geometry.layer import Layer
 from mpldts.geometry.drift_cell import DriftCell
+from mpldts.geometry.segments import Segment, Segments
+from mpldts.geometry.am_dt_segments import AMDTSegments

--- a/mpldts/geometry/_geometry.py
+++ b/mpldts/geometry/_geometry.py
@@ -3,6 +3,7 @@ import re
 import xml.etree.ElementTree as ET
 
 
+
 class DTGeometry:
     """
     A class to easy access to the CMS DT Geometry from the XML file.

--- a/mpldts/geometry/am_dt_segments.py
+++ b/mpldts/geometry/am_dt_segments.py
@@ -1,0 +1,208 @@
+from mpldts.geometry.segments import Segment, Segments
+from mpldts.geometry.station import Station
+import numpy as np
+from pandas import DataFrame
+
+
+class AMDTSegment(Segment):
+    """
+    Represents a DT AM (Analytical Method) trigger primitive segment.
+
+    Each DT AM segment is defined by its geometric center and direction. Two segment types are considered:
+
+    - **Phi segments**: ...
+    - **Theta segments**: ...
+
+    """
+
+    def __init__(
+        self,
+        number,
+        parent=None,
+        sl=None,
+        position=None,
+        angle=None,
+        reference_frame=None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.number = number
+        self.sl = sl
+        self.reference_frame = reference_frame
+
+        # Set additional attributes from kwargs
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+        if parent is not None:
+            if not isinstance(parent, Station):
+                raise TypeError("Parent must be an instance of Station.")
+            self.parent = parent
+        else:
+            raise ValueError("Parent station must be provided for the segment.")
+
+        self.wh = getattr(self.parent, "wheel", None)
+        self.sc = getattr(self.parent, "sector", None)
+        self.st = getattr(self.parent, "number", None)
+
+        self._compute_segment_properties(position, angle)
+
+    def _compute_segment_properties(self, position, angle):
+        _dx = -1 * np.sin(np.radians(angle))  # Calculate the x component of the direction vector
+        _dz = np.cos(np.radians(angle))  # Calculate the z component of the direction vector
+
+        is_sl2 = self.sl == 2
+        _center = [0, -position, 0] if is_sl2 else [position, 0, 0]
+        _direction = (
+            np.array([0, -_dx, _dz]) if is_sl2 else np.array([_dx, 0, _dz])
+        )  # direction vector in local cords
+
+        # check if user specified a reference frame
+        # if no reference frame is specified, we assume the provided position and angle are already in the station frame
+        rframe = getattr(self, "reference_frame", None) or "Station"
+        if rframe not in self.parent.transformer.available_frames:
+            raise ValueError(
+                f"The specified reference frame '{rframe}' is not available in the parent transformer."
+            )
+
+        if rframe != "Station":
+            # If the user specified a reference frame, transform the center and direction to the station frame
+            _local_center = self.parent.transformer.transform(
+                _center, from_frame=rframe, to_frame="Station"
+            )
+            _local_direction = self.parent.transformer.transform(
+                _direction, from_frame=rframe, to_frame="Station", type="vector"
+            )
+        else:
+            _local_center = _center
+            _local_direction = _direction
+
+        if (
+            self.sl != 0
+        ):  # If the segment belongs to SL1, SL2 or SL3, we transform from  vertical cord to SuperLayer frame to center it in SL
+            try:
+                _local_center[2] = self.parent.super_layer(self.sl).transformer.transform(
+                    (0, 0, 0), from_frame="SuperLayer", to_frame="Station"
+                )[2]
+            except AttributeError:
+                raise ValueError(
+                    f"Invalid SuperLayer number '{self.sl}' for the parent station{self.parent.name}. "
+                    f"It should be {[sl.number for sl in self.parent.super_layers]}."
+                )
+
+        _global_center = self.parent.transformer.transform(
+            _local_center, from_frame="Station", to_frame="CMS"
+        )  # global center in CMS coordinates
+        _global_direction = self.parent.transformer.transform(
+            _local_direction, from_frame="Station", to_frame="CMS", type="vector"
+        )  # direction in CMS coordinates
+
+        # normalize the direction vectors
+        _local_direction = _local_direction / np.sqrt(np.sum(_local_direction**2))
+        _global_direction = _global_direction / np.sqrt(np.sum(_global_direction**2))
+
+        # In this way to ensure that they are tuples of floats and not numpy types... (not very important XD)
+        self.local_center = tuple(float(i) for i in _local_center)
+        self.global_center = tuple(float(i) for i in _global_center)
+        self.local_direction = tuple(float(i) for i in _local_direction)
+        self.global_direction = tuple(float(i) for i in _global_direction)
+
+
+class AMDTSegments(Segments):
+    """
+    Represents a collection of DT AM (Analytical Method) trigger primitive segments.
+
+    Each DT AM segment is defined by its geometric center and direction. Two segment types are considered:
+
+    - **Phi segments**: ...
+    - **Theta segments**: ...
+
+    """
+
+    def __init__(self, segs_info=None, reference_frame="SL13Center"):
+        """
+        Constructor of the Segments class.
+
+        :param segs_info: Information for the segments. It could be a dictionary, a list of dictionaries,
+                or a pandas DataFrame containing the segments attributes, they should be identified by
+                e.g. ``[{"sl": 1, "angle": 2, "position": 12.2}, ...]``
+        :type segs_info: dict, list of dict, or pandas.DataFrame.
+        """
+        super().__init__()
+        if segs_info is None:
+            raise ValueError("The segments information must be provided.")
+
+        self._build_segments(segs_info, reference_frame=reference_frame)
+
+    def _build_segments(self, segements_info=None, reference_frame=None):
+        """
+        Build up the segments of the station. It creates the segments contained in the station and
+        sets the attributes.
+        """
+        if isinstance(segements_info, dict):
+            info = [segements_info]
+        elif isinstance(segements_info, DataFrame):
+            info = segements_info.to_dict(orient="records")
+        elif isinstance(segements_info, list):
+            info = segements_info
+        else:
+            raise TypeError(
+                "The segments information must be a dictionary, a list of dictionaries, or a pandas DataFrame."
+            )
+
+        for i, seg_info in enumerate(info):
+            if any(key not in seg_info for key in ["sl", "angle", "position"]):
+                raise ValueError(
+                    "Each segment information must contain 'sl', 'angle', and 'position' keys."
+                )
+
+            # Extract only the required attributes
+            sl = seg_info["sl"]
+            angle = seg_info["angle"]
+            position = seg_info["position"]
+            number = seg_info.get("index", i + 1)
+            parent = seg_info.get("parent", None)
+            wh = seg_info.get("wh", None)
+            sec = seg_info.get("sc", None)
+            st = seg_info.get("st", None)
+
+            if parent is None and (wh is None or sec is None or st is None):
+                raise ValueError(
+                    "Either 'parent' must be provided or 'wh', 'sc', and 'st' must be provided."
+                )
+
+            if parent is None:
+                parent = Station(wheel=wh, sector=sec, station=st)
+
+            # Create Segment and set additional attributes
+            _seg = AMDTSegment(
+                number,
+                parent,
+                sl,
+                position,
+                angle,
+                reference_frame=reference_frame,
+                **{
+                    k: v
+                    for k, v in seg_info.items()
+                    if k not in ["sl", "angle", "position", "index", "parent", "wh", "sc", "st"]
+                },
+            )
+
+            self.add(_seg)
+
+
+if __name__ == "__main__":
+    # Example usage
+    parent = Station(wheel=2, sector=1, station=3)
+    parent2 = Station(wheel=2, sector=1, station=4)
+    segments_info = [
+        {"parent": parent, "sl": 1, "angle": -10.2, "position": 0},
+        {"parent": parent, "sl": 3, "angle": 20.0, "position": 0},
+        {"parent": parent, "sl": 2, "angle": 0.1, "position": 10},
+        {"parent": parent2, "sl": 1, "angle": -10.2, "position": 0},
+    ]
+    segments = AMDTSegments(segments_info)
+    for seg in segments:
+        print(seg)
+    print(segments.groupby(["wh", "sc", "st"]))

--- a/mpldts/geometry/segments.py
+++ b/mpldts/geometry/segments.py
@@ -1,0 +1,255 @@
+import warnings
+from typing import Union
+
+
+class Segment:
+    """
+    A class representing a segment like object, which is simply a row that reconstruct the path of a particle traversing a detector.
+    This class is designed to manage common attributes, getters, setters, and other functionalities.
+
+    Attributes
+    ----------
+        number : int
+            Number identifier of the segment.
+        local_center : tuple
+            Local center coordinates (x, y, z) of the segment.
+        global_center : tuple
+            Global center coordinates (x, y, z) of the segment.
+        direction : tuple
+            Direction vector of the segment.
+
+    """
+
+    def __init__(self):
+        """
+        Initialize the segment.
+        """
+        pass
+
+    def __str__(self):
+        """
+        Provide a string representation of the object.
+
+        :return: String representation of the object.
+        :rtype: str
+        """
+        return (
+            f"number: {self.number}, "
+            f"local_center: {self.local_center}, "
+            f"global_center: {self.global_center}, "
+            f"local_direction: {self.local_direction} "
+            f"global_direction: {self.global_direction}"
+        )
+
+    @property
+    def number(self):
+        """
+        Number identifier of the Object.
+
+        :return: Number of the Object.
+        :rtype: int
+        """
+        try:
+            return self._number
+        except AttributeError:
+            warnings.warn(
+                f"This {self.__class__.__name__} instance does not have a Number assigned."
+            )
+            return None
+
+    @property
+    def local_center(self):
+        """
+        Local center coordinates of the Object.
+
+        :return: Local center coordinates (x, y, z).
+        :rtype: tuple
+        """
+        return self._x_local, self._y_local, self._z_local
+
+    @property
+    def local_direction(self):
+        """
+        Direction of the Object.
+
+        :return: Direction of the object.
+        :rtype: tuple
+        """
+        return self._local_direction
+
+    @property
+    def global_direction(self):
+        """
+        Global direction of the Object.
+
+        :return: Global direction of the object.
+        :rtype: tuple
+        """
+        return self._global_direction
+
+    @property
+    def global_center(self):
+        """
+        Global center coordinates of the Object.
+
+        :return: Global center coordinates (x, y, z).
+        :rtype: tuple
+        """
+        return self._x_global, self._y_global, self._z_global
+
+    @number.setter
+    def number(self, number: int):
+        """
+        Set the number of the Object.
+
+        :param number: Number of the Object.
+        :type number: int
+        """
+        self._number = number
+
+    @local_center.setter
+    def local_center(self, cords: tuple):
+        """
+        Set the local center coordinates of the Object.
+
+        :param cords: Local center coordinates (x, y, z).
+        :type cords: tuple
+        """
+        self._x_local, self._y_local, self._z_local = cords
+
+    @global_center.setter
+    def global_center(self, cords: tuple):
+        """
+        Set the global center coordinates of the Object.
+
+        :param cords: Global center coordinates (x, y, z).
+        :type cords: tuple
+        """
+        self._x_global, self._y_global, self._z_global = cords
+
+    @local_direction.setter
+    def local_direction(self, direction: tuple):
+        """
+        Set the direction of the Object.
+
+        :param direction: Direction of the Object.
+        :type direction: tuple
+        """
+        self._local_direction = direction
+
+    @global_direction.setter
+    def global_direction(self, direction: tuple):
+        """
+        Set the global direction of the Object.
+
+        :param direction: Global direction of the Object.
+        :type direction: tuple
+        """
+        self._global_direction = direction
+
+
+class Segments:
+    """
+    A class representing a collection of segments.
+
+    This class is designed to manage a collection of Segment objects, providing methods to add,
+    remove, and access segments.
+
+    Attributes
+    ----------
+        segments : list
+            List of Segment objects in the collection.
+    """
+
+    def __init__(self, segments: Union[list[Segment], Segment] = None):
+        """
+        Initialize the Segments collection.
+        """
+        self._segments = segments if isinstance(segments, list) else [segments] if segments else []
+
+    def __len__(self):
+        """
+        Return the number of segments in the collection.
+
+        :return: Number of segments.
+        :rtype: int
+        """
+        return len(self._segments)
+
+    def __getitem__(self, index):
+        """
+        Retrieve a segment by its index or slice.
+
+        :param index: Index or slice of the segment(s).
+        :type index: int or slice
+        :return: Segment or list of segments.
+        :rtype: DTSegment or list of DTSegment
+        """
+        return self._segments[index]
+
+    def __iter__(self):
+        """
+        Iterate over all segments in the collection.
+
+        :yield: Each segment in the collection.
+        :rtype: DTSegment
+        """
+        return iter(self._segments)
+
+    @property
+    def segments(self):
+        """
+        Get all the segments.
+
+        :return: List of segments.
+        :rtype: list
+        """
+        return self._segments
+
+    def get_by_number(self, numbers):
+        """
+        Retrieve a segment by its number attribute.
+
+        :param number: The number(s) of the segment to retrieve.
+        :type number: int or list of int
+        :return: Segment(s) with the specified number(s), or None if not found.
+        :rtype: DTSegment or None
+        """
+        if isinstance(numbers, int):
+            numbers = [numbers]
+        return list((segment for segment in self._segments if segment.number in numbers))
+
+    def groupby(self, attributes):
+        """
+        Group segments by one or more specified attributes.
+
+        :param attributes: The attribute(s) to group by.
+        :type attributes: str or list of str
+        :return: A dictionary where keys are tuples of attribute values and values are Segments objects containing the grouped segments.
+        :rtype: dict
+        """
+        if isinstance(attributes, str):
+            attributes = [attributes]
+
+        if not all(
+            all(hasattr(segment, attr) for attr in attributes) for segment in self._segments
+        ):
+            raise AttributeError(f"Not all segments have the specified attributes: {attributes}.")
+
+        grouped_segments = {}
+        for segment in self._segments:
+            key = tuple(getattr(segment, attr) for attr in attributes)
+            if key not in grouped_segments:
+                grouped_segments[key] = []
+            grouped_segments[key].append(segment)
+
+        return {key: Segments(value) for key, value in grouped_segments.items()}
+
+    def add(self, segment: Segment):
+        """
+        Add a Segment object to the collection.
+
+        :param segment: The Segment object to add.
+        :type segment: Segment
+        """
+        self._segments.append(segment)

--- a/mpldts/geometry/station.py
+++ b/mpldts/geometry/station.py
@@ -56,6 +56,8 @@ class Station(DTFrame):
         # == Build the station
         self._super_layers = []
         self._build_station()
+        # Set up the transformation from the SL13 center to the station frame
+        self._setup_sl13center_transformer()
 
         # == Set the drift cell attributes
         if dt_info is not None:
@@ -102,6 +104,22 @@ class Station(DTFrame):
         :rtype: list
         """
         return self._super_layers
+
+    @property
+    def face_orientation_factor(self):
+        """
+        Get the face orientation factor of the station. It is -1 for negative wheels, 1 for positive
+        wheels, and it depends on the sector for wheel 0 (it is -1 for sectors 1, 4, 5, 8, 9, 12,
+        and 13, and 1 otherwise). Details in https://dt-sx5.web.cern.ch/dt-sx5/run/docs/050912DT_type_naming.pdf
+
+        :return: Face orientation factor.
+        :rtype: int
+        """
+        return (
+            -1
+            if self._wheel < 0
+            else 1 if self._wheel > 0 else -1 if self._sector in [1, 4, 5, 8, 9, 12, 13] else 1
+        )
 
     def super_layer(self, super_layer_number):
         """
@@ -174,21 +192,19 @@ class Station(DTFrame):
 
     def _setup_tranformer(self):
         """
-        Set up the transformer for the station. It defines the transformation from the local frame to the global frame.
+        Set up the transformer for the station. It defines the transformation from the local frame
+        to the global frame and other useful transformations (e.g. for plotting).
         """
         from pytransform3d.rotations import perpendicular_to_vectors
-        from numpy import array
+        from numpy import array, arctan2, radians, sin, sqrt, pi
 
         self.transformer = TransformManager("Station")  # intial frame is the station frame
 
-        # negative wheel are facing towards the -z axis, positive wheel towards the +z axis, and 0 wheel is facing towards the +-z axis depending on the sector
-        face_orientation = (
-            -1
-            if self._wheel < 0
-            else 1 if self._wheel > 0 else -1 if self._sector in [1, 4, 5, 8, 9, 12, 13] else 1
-        )
+        # negative wheel are facing towards the -z axis, positive wheel towards the +z axis, and
+        # 0 wheel is facing towards the +-z axis depending on the sector
+        face_orientation = self.face_orientation_factor
 
-        # Define the transformation from Station frame to CMS global frame
+        # --------- Define the transformation from Station frame to CMS global frame ----------
 
         CMSezSt = self._direction
         CMSeySt = array([0, 0, 1]) * face_orientation
@@ -207,7 +223,7 @@ class Station(DTFrame):
             "Station", "CMS", rotation_matrix=_RCMSSt, translation_vector=_TCMSSt
         )  # add the transformation from local to global frame
 
-        # add a orientation transformation (Station 'Natural view' - NV phi/eta), useful for matplotlib ploting.
+        # ----- add a orientation transformation (Station 'Natural view' - NV phi/eta), useful for matplotlib plotting ------
         StNvezSt = array([0, 0, -1])
         StNvPhieySt = array([0, -1, 0]) * face_orientation
         StNvPhiexSt = perpendicular_to_vectors(StNvPhieySt, StNvezSt)
@@ -226,6 +242,47 @@ class Station(DTFrame):
         ).T  # rotation matrix from local to global frame
 
         self.transformer.add("Station", "StationNvEta", rotation_matrix=_RStNvPhiSt)
+
+        # ----- Add transformation from the Station to the sector phi line (used for AM TPs) -----
+        # dphi is the angle between the sector center line and the line from the CMS center to the station center
+        StPhi = arctan2(self._y_global, self._x_global)
+        StR = sqrt(self._x_global**2 + self._y_global**2)
+        sector = self._sector
+
+        # factor required for MB4 in sector 4 and 10 which are divided (sectors 13 and 14)
+        mb4_sign_correction = 1
+        if self._sector in [13, 14]:
+            mb4_sign_correction = -1
+            if self._sector == 13:
+                sector = 4
+            elif self._sector == 14:
+                sector = 10
+
+        SectorPhi = (sector - 1) * pi / 6  # 30 degrees per sector
+
+        dphi = StPhi - SectorPhi * mb4_sign_correction
+
+        # distance from the station center to the sector phi line
+        dx = -1 * (StR * sin(dphi)) * face_orientation * mb4_sign_correction
+
+        self.transformer.add(
+            "Station", "SectorRef", translation_vector=(dx, 0, 0)
+        )  # add the transformation from the station frame to the sector phi frame (just a translation in x)
+
+    def _setup_sl13center_transformer(self):
+        """
+        Add to the parent transformer the transformation to move from the SL13 center frame
+        to the Station frame. The SL13 center frame is defined as the geometrical center of the super layers 1 and 3.
+        The transformation is added to the parent station's transformer with the name "SL13Center".
+        """
+        from numpy import array
+
+        sl1_center = array(self.super_layer(1).local_center)
+        sl3_center = array(self.super_layer(3).local_center)
+        sls_center = (sl1_center + sl3_center) / 2
+
+        # Translation vector to move the center of SL13 frame to the Station Frame
+        self.transformer.add("SL13Center", "Station", translation_vector=sls_center)
 
     def set_cell_attrs(self, dt_info):
         """

--- a/mpldts/patches/__init__.py
+++ b/mpldts/patches/__init__.py
@@ -1,2 +1,3 @@
 from mpldts.patches.dt_station_patch import DTStationPatch
 from mpldts.patches.dt_patch_base import DTRelatedPatch
+from mpldts.patches.am_segments_patch import DTSegmentsPatch, MultiDTSegmentsPatch

--- a/mpldts/patches/am_segments_patch.py
+++ b/mpldts/patches/am_segments_patch.py
@@ -1,0 +1,175 @@
+from matplotlib.collections import LineCollection
+from mpldts.geometry import AMDTSegments
+from mpldts.patches.dt_patch_base import DTRelatedPatch
+import warnings
+
+
+class DTSegmentsPatch(DTRelatedPatch):
+    """
+    A class to visualize a 2D representation of Segments of a DT chamber in matplotlib context.
+
+    Attributes:
+    -----------
+        segments_collection : matplotlib.collections.LineCollection
+            A collection of line segments representing the segments of the station.
+        segments : AMDTSegments
+            The segments to be visualized.
+        axes : matplotlib.axes.Axes
+            The matplotlib axes to draw the patches on.
+        view : str
+            The view type, either "phi" or "eta".
+        local : bool
+            Boolean indicating whether to use local or global coordinates.
+        inverted : bool
+            Boolean indicating whether to invert the view. If local is False, this will not have any effect.
+        vmap : str
+            The variable to map to the colormap.
+
+    .. important::
+
+        Be aware that this is not a child class of ``matplotlib.patches.Patch``. Instead, it creates a
+        ``matplotlib.collections.LineCollection`` object to draw the segments as lines.
+    """
+
+    def __init__(
+        self,
+        segments: AMDTSegments,
+        axes,
+        faceview="phi",
+        local=True,
+        inverted=False,
+        vmap="quality",
+        segs_kwargs=None,
+        **kwargs,
+    ):
+        """
+        Initialize a SegmentsPatch instance.
+
+        :param segments: The segments objects containing the geometry information.
+        :type segments: AMDTSegments
+        :param axes: The matplotlib axes to draw the patches on.
+        :type axes: matplotlib.axes.Axes
+        :param faceview: The view type, either "phi" or "eta".
+        :type faceview: str, optional
+        :param local: Boolean indicating whether to use local or global coordinates.
+        :type local: bool, optional
+        :param inverted: Boolean indicating whether to invert the view. If local is False, this will not have any effect.
+        :type inverted: bool, optional
+        :param vmap: The variable to map to the colormap.
+        :type vmap: str, optional
+        :param segs_kwargs: Additional keyword arguments to apply to the LineCollection.
+        :type segs_kwargs: dict, optional
+        :return: None. Adds a collection with the line segments of a chamber to the provided matplotlib axes.
+        """
+        self.vmap = vmap
+        self.segments = segments
+
+        self.segments_collection = LineCollection(
+            [], **(segs_kwargs or {"linewidth": 0.8, "color": "k"}), **kwargs
+        )
+
+        self.parent = segments[0].parent  # All segments should have the same parent
+
+        super().__init__(
+            station=self.parent,
+            axes=axes,
+            faceview=faceview,
+            local=local,
+            inverted=inverted,
+            collections=[self.segments_collection],
+        )
+
+    def _draw_collections(self):
+        self._draw_segments()
+
+    def _draw_segments(self):
+        """
+        Draw the segments within the Station.
+        """
+        paths = []
+        vars = []
+        for seg in self.segments:
+            if self.view == "eta" and seg.sl != 2:
+                continue
+            if self.view == "phi" and seg.sl == 2:
+                continue
+            path = self._create_segment(seg)
+            var = getattr(seg, self.vmap, 0)
+
+            paths.append(path)
+            vars.append(var)
+
+        self.segments_collection.set_paths(paths)
+        self.segments_collection.set_array(vars)
+
+    def _create_segment(self, seg):
+        """
+        Create a segment (line) for the given object.
+        """
+        x, y, z = seg.local_center
+        dx, dy, dz = seg.local_direction
+        if seg.sl == 2:
+            x, y = -y, x  # Invert x and y for eta view
+            dx, dy = -dy, dx  # Invert direction for eta view
+
+        size = 20 if seg.sl != 0 else 40  # Use a smaller size for segments not correlated
+
+        x_start = x - dx * size * 0.5
+        z_start = z - dz * size * 0.5
+        x_end = x + dx * size * 0.5
+        z_end = z + dz * size * 0.5
+
+        return [[x_start, z_start], [x_end, z_end]]
+
+    def change_vmap(self, vmap):
+        """
+        Change the variable to map to the colormap.
+
+        :param vmap: The variable to map to the colormap.
+        :type vmap: str
+        """
+        self.vmap = vmap
+        vars = [getattr(seg, self.vmap, 0) for seg in self.segments]
+        self.segments_collection.set_array(vars)
+
+
+class MultiDTSegmentsPatch:
+    """
+    A class to visualize a 2D representation of Segments with multiple parent DT stations in matplotlib context.
+
+    Attributes:
+    -----------
+        patches : list
+            A list of SegmentsPatch instances, one for each parent station.
+        axes : matplotlib.axes.Axes
+            The matplotlib axes to draw the patches on.
+    """
+
+    def __init__(
+        self,
+        segments: AMDTSegments,
+        axes,
+        **kwargs,
+    ):
+        """
+        Initialize a MultiSegmentsPatch instance.
+
+        :param segments: The segments objects containing the geometry information.
+        :type segments: AMDTSegments
+        :param axes: The matplotlib axes to draw the patches on.
+        :type axes: matplotlib.axes.Axes
+        """
+        self.patches = {}
+
+        # Group segments by parent station
+        grouped_segments = segments.groupby(["wh", "sc", "st"])
+
+        for key, segs in grouped_segments.items():
+            if len(segs) == 0:
+                continue
+            patch = DTSegmentsPatch(
+                segments=segs,
+                axes=axes,
+                **kwargs,
+            )
+            self.patches[key] = patch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mplDTs"
-version = "2.0.0"
+version = "2.1.0"
 description = "Set of tools to produce CMS DTs matplotlib patches"
 authors = ["Daniel Estrada <estradadaniel@uniovi.es>"]
 readme = "README.md"

--- a/test/cms_dt_global_segments_eta.py
+++ b/test/cms_dt_global_segments_eta.py
@@ -1,0 +1,68 @@
+import matplotlib.pyplot as plt
+from mpldts.geometry import Station, AMDTSegments
+from mpldts.patches import DTStationPatch, DTSegmentsPatch
+from matplotlib.colors import BoundaryNorm
+import numpy as np
+
+dpi = 100  # Plot resolution
+
+segs_kwargs = {
+    "linewidth": 2 * 72 / dpi,
+    "color": "green",
+}
+
+# Define DT station here because can be passed as a parent to segments
+station = Station(wheel=2, sector=4, station=3)
+width, height, length = station.bounds
+
+# create a set of segments easy to identify for testing purposes
+positions = range(-100, 101, 25)
+angles  = np.linspace(-0.5, .51, len(positions))
+num_segments = len(positions)
+
+segments_info = [
+    {"index": i, "parent": station, "sl": 2, "angle": np.degrees(angle), "position": x}
+    for i, (angle, x) in enumerate(zip(angles, positions), start=1)
+]
+
+# Create figure and subplots
+fig, axs = plt.subplots(2, 1, figsize=(10, 5), dpi=dpi)
+axs  = axs.flatten()
+
+colors = ['purple', 'orange', 'blue']
+for i, (ax, ref_frame) in enumerate(zip(axs, ["Station", "SL13Center"])):
+    # Create segments with the provided information
+    segments = AMDTSegments(segs_info=segments_info, reference_frame=ref_frame)
+
+    # Create patches for eta-view
+    _ = DTStationPatch(station, axes=ax, faceview="eta", local=False)
+
+    _ = DTSegmentsPatch(segments, axes=ax, faceview="eta", local=False, segs_kwargs=segs_kwargs)
+
+    # Draw a dot in the the reference frames
+    x, y, z = station.transformer.transform((0, 0, 0), from_frame=ref_frame, to_frame="CMS")
+    r = np.sqrt(x**2 + y**2)
+    ax.plot(z, r, 'o', color=colors[i], label=ref_frame + ' Center')
+    # add reference lines
+    ax.vlines(z, r - height / 2, r + height / 2, color=colors[i], linestyles='dashed', linewidth=1)
+
+    # Add text annotations for the segments
+    for i, xs in enumerate(positions, start=1):
+        _xs, _ys, _zs = station.transformer.transform((0,-xs-2, 0), from_frame=ref_frame, to_frame="CMS")
+        _rs = np.sqrt(_xs**2 + _ys**2)
+        ax.text(_zs, _rs, f'idx={i}', ha='center', va='top', fontsize=8)
+
+    # Set axis limits for phi-view
+    ax.set_xlim(z - length / 2 - 5, z + length / 2 + 5)
+    ax.set_ylim(r - height / 2 - 5, r + height / 2 + 5)
+
+    # Add labels and legend
+    ax.set_xlabel("z [cm]")
+    ax.set_ylabel("r [cm]")
+    ax.set_aspect('equal')
+    ax.legend(loc='upper left', fontsize=5)
+
+# Add title
+fig.suptitle(f"Segments in DT Station : {station.name} - eta-view (global)", fontsize=12)
+plt.show()
+fig.savefig("test_cms_dt_global_segments_eta.png", dpi=dpi)

--- a/test/cms_dt_global_segments_phi.py
+++ b/test/cms_dt_global_segments_phi.py
@@ -1,0 +1,70 @@
+import matplotlib.pyplot as plt
+from mpldts.geometry import Station, AMDTSegments
+from mpldts.patches import DTStationPatch, DTSegmentsPatch
+from matplotlib.colors import BoundaryNorm
+import numpy as np
+
+dpi = 100  # Plot resolution
+
+segs_kwargs = {
+    "linewidth": 2 * 72 / dpi,
+    "color": "green",
+}
+colors = ['purple', 'orange', 'blue']
+
+# create a set of segments easy to identify for testing purposes
+positions = range(-150, 151, 50)
+angles  = np.linspace(-0.5, .51, len(positions))
+num_segments = len(positions)
+sl_values = [1] * (num_segments // 3) + [0] * (num_segments // 3) + [3] * (num_segments - 2 * (num_segments // 3))
+
+segments_info = [
+    {"index": i, "sl": sl, "angle": np.degrees(angle), "position": x}
+    for i, (angle, x, sl) in enumerate(zip(angles, positions, sl_values), start=1)
+]
+
+# Create figure and subplots
+fig, axs = plt.subplots(1, 3, figsize=(10, 5), dpi=dpi)
+axs  = axs.flatten()
+
+for i, (ax, ref_frame) in enumerate(zip(axs, ["Station", "SectorRef", "SL13Center"])):
+    # Define DT station here because can be passed as a parent to segments
+    station = Station(wheel=0, sector=1, station=3)
+    width, height, length = station.bounds
+
+    for seg_info in segments_info:
+        seg_info["parent"] = station
+
+    # Create segments with the provided information
+    segments = AMDTSegments(segs_info=segments_info, reference_frame=ref_frame)
+
+    # Create patches for phi-view and eta-view
+    _ = DTStationPatch(station, axes=ax, faceview="phi", local=False)
+
+    _ = DTSegmentsPatch(segments, axes=ax, faceview="phi", local=False, segs_kwargs=segs_kwargs)
+
+    # Draw a dot in the the reference frames
+    x,y,_ = station.transformer.transform((0, 0, 0), from_frame=ref_frame, to_frame="CMS")
+    ax.plot(x, y, 'o', color=colors[i], label=ref_frame + ' Center')
+    # add reference lines
+    ax.hlines(y, x-height / 2, x + height / 2, color=colors[i], linestyles='dashed', linewidth=2)
+
+    # Add text annotations for the segments
+    for i, xs in enumerate(positions, start=1):
+        _xs, _ys, _ = station.transformer.transform((xs+2, 0, 0), from_frame=ref_frame, to_frame="CMS")
+        ax.text(_xs, _ys, f'idx={i}', ha='center', va='top', fontsize=8)
+
+    # # Set axis limits for phi-view
+    ax.set_xlim(580, 650)
+    ax.set_ylim(-150, 200)
+    ax.set_title(f"Ref Frame: {ref_frame}")
+    # Add labels and legend
+    ax.set_xlabel("x [cm]")
+    ax.set_ylabel("y [cm]")
+    ax.set_aspect('equal')
+    ax.legend(loc='upper left', fontsize=5)
+
+# Add title
+fig.suptitle(f"Segments in DT Station : {station.name} - phi-view (global)", fontsize=12)
+plt.show()
+fig.savefig("test_cms_dt_global_segments_phi.png", dpi=dpi)

--- a/test/cms_dt_local_segments_eta.py
+++ b/test/cms_dt_local_segments_eta.py
@@ -1,0 +1,67 @@
+import matplotlib.pyplot as plt
+from mpldts.geometry import Station, AMDTSegments
+from mpldts.patches import DTStationPatch, DTSegmentsPatch
+from matplotlib.colors import BoundaryNorm
+import numpy as np
+
+dpi = 100  # Plot resolution
+
+segs_kwargs = {
+    "linewidth": 2 * 72 / dpi,
+    "color": "green",
+}
+
+# Define DT station here because can be passed as a parent to segments
+station = Station(wheel=2, sector=4, station=3)
+width, height, length = station.bounds
+
+# create a set of segments easy to identify for testing purposes
+positions = range(-100, 101, 25)
+angles  = np.linspace(-0.5, .51, len(positions))
+num_segments = len(positions)
+
+segments_info = [
+    {"index": i, "parent": station, "sl": 2, "angle": np.degrees(angle), "position": x}
+    for i, (angle, x) in enumerate(zip(angles, positions), start=1)
+]
+
+# Create figure and subplots
+fig, axs = plt.subplots(2, 1, figsize=(10, 5), dpi=dpi)
+axs  = axs.flatten()
+
+colors = ['purple', 'orange', 'blue']
+for i, (ax, ref_frame) in enumerate(zip(axs, ["Station", "SL13Center"])):
+    # Create segments with the provided information
+    segments = AMDTSegments(segs_info=segments_info, reference_frame=ref_frame)
+
+    # Create patches for eta-view
+    _ = DTStationPatch(station, axes=ax, faceview="eta", local=True, inverted=False)
+
+    _ = DTSegmentsPatch(segments, axes=ax, faceview="eta", local=True, inverted=False, segs_kwargs=segs_kwargs)
+
+    # Draw a dot in the the reference frames
+    _, y, z = station.transformer.transform((0, 0, 0), from_frame=ref_frame, to_frame="Station")
+    x = -y
+    ax.plot(x, z, 'o', color=colors[i], label=ref_frame + ' Center')
+    # add reference lines
+    ax.vlines(x, -height / 2, height / 2, color=colors[i], linestyles='dashed', linewidth=1)
+
+    # Add text annotations for the segments
+    for i, xs in enumerate(positions, start=1):
+        _xs = -1 * station.transformer.transform((xs+2, 0, 0), from_frame=ref_frame, to_frame="Station")[1]
+        ax.text(_xs, 0, f'idx={i}', ha='center', va='top', fontsize=8)
+
+    # Set axis limits for phi-view
+    ax.set_xlim(- length / 2 - 5, length / 2 + 5)
+    ax.set_ylim(- height / 2 - 5, height / 2 + 5)
+
+    # Add labels and legend
+    ax.set_xlabel("y [cm]")
+    ax.set_ylabel("z [cm]")
+    ax.set_aspect('equal')
+    ax.legend(loc='upper left', fontsize=5)
+
+# Add title
+fig.suptitle(f"Segments in DT Station : {station.name}- eta-view (local)", fontsize=12)
+plt.show()
+fig.savefig("test_cms_dt_local_segments_eta.png", dpi=dpi)

--- a/test/cms_dt_local_segments_phi.py
+++ b/test/cms_dt_local_segments_phi.py
@@ -1,0 +1,69 @@
+import matplotlib.pyplot as plt
+from mpldts.geometry import Station, AMDTSegments
+from mpldts.patches import DTStationPatch, DTSegmentsPatch
+from matplotlib.colors import BoundaryNorm
+import numpy as np
+
+dpi = 100  # Plot resolution
+
+segs_kwargs = {
+    "linewidth": 2 * 72 / dpi,
+    "color": "green",
+}
+
+# Define DT station here because can be passed as a parent to segments
+station = Station(wheel=2, sector=4, station=1)
+width, height, length = station.bounds
+
+# create a set of segments easy to identify for testing purposes
+positions = range(-100, 101, 25)
+angles  = np.linspace(-0.5, .51, len(positions))
+num_segments = len(positions)
+sl_values = [1] * (num_segments // 3) + [0] * (num_segments // 3) + [3] * (num_segments - 2 * (num_segments // 3))
+
+segments_info = [
+    {"index": i, "parent": station, "sl": sl, "angle": np.degrees(angle), "position": x}
+    for i, (angle, x, sl) in enumerate(zip(angles, positions, sl_values), start=1)
+]
+
+# Create figure and subplots
+fig, axs = plt.subplots(3, 1, figsize=(10, 5), dpi=dpi)
+axs  = axs.flatten()
+
+colors = ['purple', 'orange', 'blue']
+for i, (ax, ref_frame) in enumerate(zip(axs, ["Station", "SectorRef", "SL13Center"])):
+    # Create segments with the provided information
+    segments = AMDTSegments(segs_info=segments_info, reference_frame=ref_frame)
+
+    # Create patches for phi-view
+    _ = DTStationPatch(station, axes=ax, faceview="phi", local=True, inverted=False)
+
+    _ = DTSegmentsPatch(segments, axes=ax, faceview="phi", local=True, inverted=False, segs_kwargs=segs_kwargs)
+
+    # Draw a dot in the the reference frames
+    x,_,z = station.transformer.transform((0, 0, 0), from_frame=ref_frame, to_frame="Station")
+    ax.plot(x, z, 'o', color=colors[i], label=ref_frame + ' Center')
+    # add reference lines
+    ax.vlines(x, -height / 2, height / 2, color=colors[i], linestyles='dashed', linewidth=1)
+
+    # Add text annotations for the segments
+    for i, xs in enumerate(positions, start=1):
+        _xs = station.transformer.transform((xs+2, 0, 0), from_frame=ref_frame, to_frame="Station")[0]
+        ax.text(_xs, 0, f'idx={i}', ha='center', va='top', fontsize=8)
+
+    # Set axis limits for phi-view
+    ax.set_xlim(- width / 2 - 5, width / 2 + 5)
+    ax.set_ylim(- height / 2 - 5, height / 2 + 5)
+
+    # Add labels and legend
+    ax.set_xlabel("x [cm]")
+    ax.set_ylabel("z [cm]")
+    ax.set_aspect('equal')
+    ax.legend(loc='upper left', fontsize=5)
+
+# Add title
+fig.suptitle(f"Segments in DT Station : {station.name} - phi-view (local)", fontsize=12)
+# Create a single legend box positioned in the center left
+fig.tight_layout() 
+plt.show()
+fig.savefig("test_cms_dt_local_segments_phi.png", dpi=dpi)

--- a/test/cms_dts_phi_zoomed.py
+++ b/test/cms_dts_phi_zoomed.py
@@ -27,7 +27,7 @@ for sc in range(1, 15):
     for st in range(1, 5):
         if (sc == 13 or sc == 14) and st != 4:
             continue  # Sector 13 and 14 are only one MB4 station
-        station = Station(wheel=-2, sector=sc, station=st)
+        station = Station(wheel=2, sector=sc, station=st)
         _ = DTStationPatch(
             station,
             axes=ax,

--- a/test/cms_dts_segments.py
+++ b/test/cms_dts_segments.py
@@ -1,0 +1,60 @@
+import matplotlib.pyplot as plt
+from mpldts.geometry import Station, AMDTSegments
+from mpldts.patches import MultiDTSegmentsPatch, DTStationPatch
+from matplotlib.colors import BoundaryNorm
+
+dpi = 100  # Plot resolution
+
+# Configure colormap and normalization for the plot
+cmap = plt.get_cmap('viridis', 9)  # Ensure the colormap has 9 discrete colors
+cmap.set_under('none')  # Set color for values below the minimum
+quality_norm = BoundaryNorm(boundaries=[0.1, 1, 2, 3, 4, 5, 6, 7, 8, 9], ncolors=9, clip=True)
+
+segs_kwargs = {
+    "linewidth": 3 * 72 / dpi,
+    "cmap": cmap,
+    "norm": quality_norm,
+}
+
+# Define multiple DT stations
+station1 = Station(wheel=2, sector=1, station=3)
+station2 = Station(wheel=2, sector=2, station=3)
+station3 = Station(wheel=2, sector=3, station=3)
+
+segments_info = [
+    {"index": 1, "parent": station1, "sl": 3, "angle": 1, "position": -100, "q": 1},
+    {"index": 2, "parent": station1, "sl": 3, "angle": 0.2, "position": -50, "q": 2},
+    {"index": 3, "parent": station2, "sl": 3, "angle": 0.05, "position": 0, "q": 3},
+    {"index": 4, "parent": station2, "sl": 1, "angle": 30, "position": -15, "q": 2},
+    {"index": 5, "parent": station3, "sl": 1, "angle": -7, "position": -75, "q": 7},
+    {"index": 6, "parent": station3, "sl": 1, "angle": 8, "position": 2, "q": 8},
+]
+
+# Create figure and subplots
+fig, axs = plt.subplots(1, 1, figsize=(7, 7), dpi=dpi)
+
+# Create the station patches for each station
+dt_patch_station1 = DTStationPatch(station1, axes=axs, faceview="phi", local=False)
+dt_patch_station2 = DTStationPatch(station2, axes=axs, faceview="phi", local=False)
+dt_patch_station3 = DTStationPatch(station3, axes=axs, faceview="phi", local=False)
+
+# Create segments with the provided information
+segments = AMDTSegments(segs_info=segments_info)
+
+# Create patches for each station
+segs_patch_station1 = MultiDTSegmentsPatch(
+    segments, axes=axs, faceview="phi", local=False, vmap="q",
+    segs_kwargs=segs_kwargs
+)
+
+
+# Add titles and labels
+axs.set_title("Segments in Multiple DT Stations")
+
+axs.set_xlabel("x [cm]")
+axs.set_ylabel("y [cm]")
+
+axs.set_xlim(000, 800)
+axs.set_ylim(-200, 700)
+
+plt.show()


### PR DESCRIPTION
This PR adds graphical "patches" that render reconstructed DT segments (AM trigger primitives) on top of the detector geometry plots. This closes issue #7.

**Key changes (with references)**
- Added generic segment geometry abstractions and base classes to represent segments consistently across frames: https://github.com/INTREPID-hep/mplDTs/blob/d35259a3c12d4d52a1597c41ca95e82491a2caa9/mpldts/geometry/segments.py
- Implemented AM-specific segment geometry classes to compute AM segment properties: https://github.com/INTREPID-hep/mplDTs/blob/d35259a3c12d4d52a1597c41ca95e82491a2caa9/mpldts/geometry/am_dt_segments.py#L50-L108
- Added AM reference-frame transformations to the station transformer to convert local AM quantities into DT Station and CMS global coordinates: https://github.com/INTREPID-hep/mplDTs/blob/d35259a3c12d4d52a1597c41ca95e82491a2caa9/mpldts/geometry/station.py#L246-L285
- Added AM segment patch classes so reconstructed segments can be drawn alongside detector elements: https://github.com/INTREPID-hep/mplDTs/blob/d35259a3c12d4d52a1597c41ca95e82491a2caa9/mpldts/patches/am_segments_patch.py

**How it works / usage**
- Provide the segment local position and angle to the patch constructor, plus the reference frame used for the input.
- Internally, the segment is transformed from that reference frame to Station and CMS global coordinates and its geometry is cached so it can be rendered consistently with the station/geometry plot.
- 

**Testing**
- Existing tests live in [mplDTs/test/](https://github.com/INTREPID-hep/mplDTs/test) cover geometry and plotting behavior. They simply draw the follow set of prove segments assuming different reference frames:
  ```python
  [
    {'index': 1, 'sl': 1, 'angle': -28.65, 'position': -100},
    {'index': 2, 'sl': 1, 'angle': -21.41, 'position': -75},
    {'index': 3, 'sl': 1, 'angle': -14.18, 'position': -50},
    {'index': 4, 'sl': 0, 'angle': -6.95, 'position': -25},
    {'index': 5, 'sl': 0, 'angle': 0.29, 'position': 0},
    {'index': 6, 'sl': 0, 'angle': 7.52, 'position': 25},
    {'index': 7, 'sl': 3, 'angle': 14.75, 'position': 50},
    {'index': 8, 'sl': 3, 'angle': 21.99, 'position': 75},
    {'index': 9, 'sl': 3, 'angle': 29.22, 'position': 100},
  ]
  ```

  
<img width="400" src="https://github.com/user-attachments/assets/5ffb5c46-deea-4824-8c4d-4bfaa398afb7" />
<img width="400" src="https://github.com/user-attachments/assets/9f6e08a3-9e19-466c-ae8a-6d35faa582ca" />

<img width="400" src="https://github.com/user-attachments/assets/55c4b45c-1e3b-4915-b405-589fb05a232f" />
<img width="400" src="https://github.com/user-attachments/assets/c1498ebe-59cc-42b8-b41f-0fce8e2d45fd" />


